### PR TITLE
Display bus stops

### DIFF
--- a/cinnabar-style.yaml
+++ b/cinnabar-style.yaml
@@ -5065,23 +5065,23 @@ layers:
                         font:
                             style: italic
 
-        # TODO: this isn't working, should see small icons near the transbay terminal in SF
         bus_stop:
             filter:
                 kind: [bus_stop]
             draw:
                 icons:
-                    size: 14px
+                    size: 20px
+                    visible: true
                     text:
                         font:
                             size: 11px
                             weight: normal
             later:
-                filter: { $zoom: { max: 19 } }
+                filter: { $zoom: { min: 19 } }
                 draw:
                     icons:
                         text:
-                            visible: false
+                            visible: true
 
         airport-gate:
             filter: { kind: aeroway_gate }


### PR DESCRIPTION
Fixes #28 

This pull request displays bus stops at z18 and their labels at z19.  I've set visible: true for both, but you may want to use a global parameter to allow easy switching on and off.