### PR TITLE
fix bus_stop display

### DIFF
--- a/cinnabar-style.yaml
+++ b/cinnabar-style.yaml
@@ -5084,12 +5084,13 @@ layers:
                 kind: [bus_stop]
             draw:
                 icons:
-                    size: 14px
+                    size: [[18,12px],[20,18px]]
                     text:
+                        optional: true
                         font:
                             size: 11px
                             weight: normal
-            later:
+            early:
                 filter: { $zoom: { max: 19 } }
                 draw:
                     icons:


### PR DESCRIPTION
fixes #28 to add all bus stops, optionally name them at later zooms

Replaces #29.