### PR TITLE
Make address labels visible at zoom 17 to match building labels

### DIFF
--- a/cinnabar-style.yaml
+++ b/cinnabar-style.yaml
@@ -2746,7 +2746,7 @@ layers:
             filter:
                 all:
                     - function() { return global.text_visible_address; }
-                    - $zoom: { min: 20 }
+                    - $zoom: { min: 17 }
                 any:
                     - kind: address
                     - { label_position: true, addr_housenumber: true, name: false }

--- a/themes/color-cinnabar.yaml
+++ b/themes/color-cinnabar.yaml
@@ -5,7 +5,7 @@ global:
     text_fill2:             [0.000,0.000,0.000]     # BLACK
     text_fill_road_e:       [0.333,0.333,0.333]     # DARK GRAY
     text_fill_exits:        '#D16768'               # motorway junctions, highway_casing1
-    text_fill_address:      [0.667,0.667,0.667]     # GRAY
+    text_fill_address:      [0.333,0.333,0.333]     # DARK GRAY
     text_fill_water:        '#4c89b5'               # blue
     text_fill_park:         '#43a254'               # green
     text_fill_beach:        '#99905c'               # green


### PR DESCRIPTION
I'm using the cinnabar style in the StreetComplete app, with the `label-11.yaml` theme. At present the housenumbers don't show up until zoomed in too far to be useful. This PR changes the house-numbers to show up (if specified in the theme) at z17, same as the building labels.