### PR TITLE
Make default building height 5 metres (1 story)

### DIFF
--- a/themes/color-cinnabar.yaml
+++ b/themes/color-cinnabar.yaml
@@ -152,4 +152,4 @@ global:
     building2:          [0.600,0.600,0.600]     # building stroke
     sdk_building_extrude:  true                 # building extrude
     building_extrude_height: |                  # building extrude height logic
-        function() { return feature.height || 20; }
+        function() { return feature.height || 5; }


### PR DESCRIPTION
When some buildings are mapped with 1 or 2 levels around an area, which seems to amount to 5 and 8 metres in the vector tiles, the default height of 20 metres (typically for sheds and garages, which StreetComplete isn't asking for levels for) towers over the other buildings.

I have submitted this PR for a more sensible 5 metre default for the building heights.